### PR TITLE
SurfaceViewのサイズ指定を他の要素に合わせて修正

### DIFF
--- a/app/src/main/res/layout/activity_add_diary.xml
+++ b/app/src/main/res/layout/activity_add_diary.xml
@@ -7,8 +7,8 @@
     tools:context="com.picturediary.AddDiaryActivity">
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -45,7 +45,8 @@
             android:layout_height="wrap_content" />
 
         <SurfaceView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="0dip"
+            android:layout_width="match_parent"
+            android:layout_weight="1" />
     </LinearLayout>
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
TextViewやEditTextは相対的なサイズ指定となっていたが、
SurfaceViewだけが親に内接するまで最大化する指定となっていたので、
SurfaceViewの最大化が優先され、他の要素がつぶれていた

視覚的に判別しやすいように等比率になるよう修正した。
![screenshot_1508768194](https://user-images.githubusercontent.com/950573/31894326-17a50abc-b849-11e7-90b5-ef63ed166a10.png)
